### PR TITLE
REL-32 'API 5.2 릴리즈 노트 생성' 수정

### DIFF
--- a/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
+++ b/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
@@ -41,10 +41,11 @@ public class ReleaseController {
      */
     @PostMapping(value = "/projects/{projectId}")
     public BaseResponse<ReleaseCreateAndUpdateResponseDto> createReleaseNote(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable @Min(value = 1, message = "프로젝트 식별 번호는 1 이상의 숫자여야 합니다.") Long projectId,
             @RequestBody @Valid ReleaseCreateRequestDto releaseCreateRequestDto) {
 
-        return new BaseResponse<>(releaseService.createReleaseNote(projectId, releaseCreateRequestDto));
+        return new BaseResponse<>(releaseService.createReleaseNote(userPrincipal.getEmail(), projectId, releaseCreateRequestDto));
     }
 
     /**

--- a/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
+++ b/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
@@ -15,7 +15,7 @@ public interface ReleaseService {
     /**
      * 5.2 릴리즈 노트 생성
      */
-    ReleaseCreateAndUpdateResponseDto createReleaseNote(Long project, ReleaseCreateRequestDto releaseCreateRequestDto);
+    ReleaseCreateAndUpdateResponseDto createReleaseNote(String userEmail, Long project, ReleaseCreateRequestDto releaseCreateRequestDto);
 
     /**
      * 5.3 릴리즈 노트 수정

--- a/src/main/java/com/momentum/releaser/domain/release/domain/ReleaseApproval.java
+++ b/src/main/java/com/momentum/releaser/domain/release/domain/ReleaseApproval.java
@@ -28,6 +28,11 @@ public class ReleaseApproval extends BaseTime {
     @JoinColumn(name = "release_id")
     private ReleaseNote release;
 
+    /**
+     * P(Pending): 배포 대기 (Default)
+     * Y(Yes): 배포 동의
+     * N(No): 배포 거부
+     */
     @Column(name = "approval")
     private char approval;
 
@@ -52,9 +57,13 @@ public class ReleaseApproval extends BaseTime {
         this.release = null;
         this.member = null;
     }
+
+    /**
+     * 데이터베이스에 초기화/저장되기 전에 자동으로 값을 초기화시킨다.
+     */
     @PrePersist
     public void prePersist() {
-        this.approval = (this.approval == '\0') ? 'N' : this.approval;
+        this.approval = (this.approval == '\0') ? 'P' : this.approval;
     }
 
     /**


### PR DESCRIPTION
## Description
- JWT 토큰으로 사용자 식별
- 사용자가 프로젝트의 관리자인지 멤버인지 확인
- 프로젝트의 관리자인 경우에만 릴리즈 노트 생성 가능
- 릴리즈 노트 생성 시 approval 기본 상태 값을 'P'로 변경