### PR TITLE
REL-33 'API 5.3 릴리즈 노트 수정' 관리자 권한 추가

### DIFF
--- a/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
+++ b/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
@@ -53,10 +53,11 @@ public class ReleaseController {
      */
     @PatchMapping(value = "/{releaseId}")
     public BaseResponse<ReleaseCreateAndUpdateResponseDto> updateReleaseNote(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable @Min(value = 1, message = "릴리즈 식별 번호는 1 이상의 숫자여야 합니다.") Long releaseId,
             @RequestBody @Valid ReleaseUpdateRequestDto releaseUpdateRequestDto) {
 
-        return new BaseResponse<>(releaseService.updateReleaseNote(releaseId, releaseUpdateRequestDto));
+        return new BaseResponse<>(releaseService.updateReleaseNote(userPrincipal.getEmail(), releaseId, releaseUpdateRequestDto));
     }
 
     /**

--- a/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
+++ b/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
@@ -20,7 +20,7 @@ public interface ReleaseService {
     /**
      * 5.3 릴리즈 노트 수정
      */
-    ReleaseCreateAndUpdateResponseDto updateReleaseNote(Long releaseId, ReleaseUpdateRequestDto releaseUpdateRequestDto);
+    ReleaseCreateAndUpdateResponseDto updateReleaseNote(String userEmail, Long releaseId, ReleaseUpdateRequestDto releaseUpdateRequestDto);
 
     /**
      * 5.4 릴리즈 노트 삭제


### PR DESCRIPTION
## Description
- JWT 토큰으로 사용자 식별
- 만약 프로젝트 관리자가 아닌 멤버라면 예외 발생
- 프로젝트 관리자만 릴리즈 노트 수정이 가능하도록 변경