### PR TITLE
REL-36 'API 5.6 릴리즈 노트 배포 동의 여부 선택' 수정

### DIFF
--- a/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
+++ b/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
@@ -84,12 +84,13 @@ public class ReleaseController {
     /**
      * 5.6 릴리즈 노트 배포 동의 여부 선택 (멤버용)
      */
-    @PostMapping(value = "/{releaseId}/approval")
+    @PostMapping(value = "/{releaseId}/approvals")
     public BaseResponse<List<ReleaseApprovalsResponseDto>> decideOnApprovalByMember(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable @Min(value = 1, message = "릴리즈 식별 번호는 1 이상의 숫자여야 합니다.") Long releaseId,
             @RequestBody @Valid ReleaseApprovalRequestDto releaseApprovalRequestDto) {
 
-        return new BaseResponse<>(releaseService.decideOnApprovalByMember(releaseId, releaseApprovalRequestDto));
+        return new BaseResponse<>(releaseService.decideOnApprovalByMember(userPrincipal.getEmail(), releaseId, releaseApprovalRequestDto));
     }
 
     /**

--- a/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
+++ b/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
@@ -35,7 +35,7 @@ public interface ReleaseService {
     /**
      * 5.6 릴리즈 노트 배포 동의 여부 선택 (멤버용)
      */
-    List<ReleaseApprovalsResponseDto> decideOnApprovalByMember(Long releaseId, ReleaseApprovalRequestDto releaseApprovalRequestDto);
+    List<ReleaseApprovalsResponseDto> decideOnApprovalByMember(String userEmail, Long releaseId, ReleaseApprovalRequestDto releaseApprovalRequestDto);
 
     /**
      * 5.7 릴리즈 노트 그래프 좌표 추가

--- a/src/main/java/com/momentum/releaser/domain/release/dto/ReleaseRequestDto.java
+++ b/src/main/java/com/momentum/releaser/domain/release/dto/ReleaseRequestDto.java
@@ -90,16 +90,11 @@ public class ReleaseRequestDto {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class ReleaseApprovalRequestDto {
-        @NotNull(message = "프로젝트 멤버 식별 번호는 1 이상의 숫자여야 합니다.")
-        @Min(value = 1, message = "프로젝트 멤버 식별 번호는 1 이상의 숫자여야 합니다.")
-        private Long memberId;
-
-        @Pattern(regexp = "(?i)^[YN]$", message = "Y 또는 N 값을 입력해 주세요.")
+        @Pattern(regexp = "(?i)^[PYN]$", message = "P, Y, N 값 중 하나를 입력해 주세요.")
         private String approval;
 
         @Builder
-        public ReleaseApprovalRequestDto(Long memberId, String approval) {
-            this.memberId = memberId;
+        public ReleaseApprovalRequestDto(String approval) {
             this.approval = approval;
         }
     }


### PR DESCRIPTION
## Description
- JWT 토큰으로 사용자 식별하도록 변경
- 배포 동의 여부로 P, N, Y 값을 사용할 수 있도록 변경