### PR TITLE
REL-36 feat: 릴리즈 노트 배포 기능 추가

### DIFF
--- a/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
+++ b/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
@@ -83,7 +83,7 @@ public class ReleaseController {
     }
 
     /**
-     * 5.6 릴리즈 노트 배포 동의 여부 선택 (멤버용)
+     * 5.6 릴리즈 노트 배포 동의 여부 선택
      */
     @PostMapping(value = "/{releaseId}/approvals")
     public BaseResponse<List<ReleaseApprovalsResponseDto>> decideOnApprovalByMember(

--- a/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
+++ b/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
@@ -33,7 +33,7 @@ public interface ReleaseService {
     ReleaseInfoResponseDto getReleaseNoteInfo(String userEmail, Long releaseId);
 
     /**
-     * 5.6 릴리즈 노트 배포 동의 여부 선택 (멤버용)
+     * 5.6 릴리즈 노트 배포 동의 여부 선택
      */
     List<ReleaseApprovalsResponseDto> decideOnApprovalByMember(String userEmail, Long releaseId, ReleaseApprovalRequestDto releaseApprovalRequestDto);
 

--- a/src/main/java/com/momentum/releaser/domain/release/domain/ReleaseNote.java
+++ b/src/main/java/com/momentum/releaser/domain/release/domain/ReleaseNote.java
@@ -171,4 +171,11 @@ public class ReleaseNote extends BaseTime {
         this.coordX = coordX;
         this.coordY = coordY;
     }
+
+    /**
+     * 릴리즈 노트 배포 상태를 업데이트한다.
+     */
+    public void updateDeployStatus(ReleaseDeployStatus deployStatus) {
+        this.deployStatus = deployStatus;
+    }
 }

--- a/src/main/java/com/momentum/releaser/domain/release/dto/ReleaseResponseDto.java
+++ b/src/main/java/com/momentum/releaser/domain/release/dto/ReleaseResponseDto.java
@@ -114,13 +114,15 @@ public class ReleaseResponseDto {
         private Long memberId;
         private String memberName;
         private String memberProfileImg;
+        private char position;
         private char approval;
 
         @Builder
-        public ReleaseApprovalsResponseDto(Long memberId, String memberName, String memberProfileImg, char approval) {
+        public ReleaseApprovalsResponseDto(Long memberId, String memberName, String memberProfileImg, char position, char approval) {
             this.memberId = memberId;
             this.memberName = memberName;
             this.memberProfileImg = memberProfileImg;
+            this.position = position;
             this.approval = approval;
         }
     }

--- a/src/main/java/com/momentum/releaser/domain/release/mapper/ReleaseMapper.java
+++ b/src/main/java/com/momentum/releaser/domain/release/mapper/ReleaseMapper.java
@@ -59,6 +59,7 @@ public interface ReleaseMapper {
     @Mapping(target = "memberId", source = "releaseApproval.member.memberId")
     @Mapping(target = "memberName", source = "releaseApproval.member.user.name")
     @Mapping(target = "memberProfileImg", source = "releaseApproval.member.user.img")
+    @Mapping(target = "position", source = "releaseApproval.member.position")
     ReleaseApprovalsResponseDto toReleaseApprovalsResponseDto(ReleaseApproval releaseApproval);
 
     /**

--- a/src/main/java/com/momentum/releaser/global/config/BaseResponseStatus.java
+++ b/src/main/java/com/momentum/releaser/global/config/BaseResponseStatus.java
@@ -21,6 +21,7 @@ public enum BaseResponseStatus {
     NOT_PROJECT_PM(false, 2200, "해당 프로젝트의 관리자가 아닙니다."),
     INVALID_RELEASE_VERSION_TYPE(false, 2400, "릴리즈 버전 타입이 올바르지 않습니다. MAJOR, MINOR, PATCH 중 하나여야 합니다."),
     EXISTS_DEPLOYED_RELEASE_NOTE_AFTER_THIS(false, 2401, "배포된 상위 버전의 릴리즈 노트가 있어 삭제할 수 없습니다."),
+    EXISTS_NOT_DEPLOYED_RELEASE_NOTE_BEFORE_THIS(false, 2402, "배포되지 않은 하위 버전의 릴리즈 노트가 있어 현재 릴리즈 노트를 배포할 수 없습니다."),
     INVALID_ISSUE_TAG(false, 2500, "이슈 태그가 올바르지 않습니다."),
     INVALID_LIFECYCLE(false, 2501, "이슈 상태가 올바르지 않습니다."),
     CONNECTED_ISSUE_EXISTS(false, 2502, "릴리즈와 연결된 이슈이므로 상태 변경이 불가능합니다."),
@@ -72,6 +73,7 @@ public enum BaseResponseStatus {
     NOT_EXISTS_RELEASE_APPROVAL(false, 4413, "존재하지 않는 릴리즈 배포 동의 여부 데이터입니다."),
     FAILED_TO_GET_RELEASE_APPROVALS(false, 4414, "릴리즈 노트 배포 동의 데이터를 불러오기에 실패하였습니다."),
     NOT_EXISTS_RELEASE_OPINION(false, 4415, "존재하지 않는 릴리즈 노트 의견입니다."),
+    EXISTS_DISAPPROVED_MEMBER(false, 4416, "릴리즈 노트 배포를 동의하지 않은 멤버가 있습니다."),
 
     NOT_EXISTS_ISSUE(false, 4500, "존재하지 않는 이슈입니다."),
     INVALID_ISSUE_WITH_COMPLETED(false, 4501, "이미 연결된 이슈가 포함되어 있습니다."),
@@ -79,9 +81,6 @@ public enum BaseResponseStatus {
     FAILED_TO_CONNECT_ISSUE_WITH_RELEASE_NOTE(false, 4503, "이슈 연결에 실패하였습니다."),
     NOT_EXISTS_ISSUE_OPINION(false, 4504, "존재하지 않는 이슈 의견입니다."),
     NOT_ISSUE_COMMENTER(false, 4505, "해당 의견 작성자가 아닙니다.");
-
-
-
 
     private final boolean isSuccess;
     private final int code;


### PR DESCRIPTION
## Description
- API 5.6 반환 값에 프로젝트 멤버 역할 추가
- API 5.6을 통해 프로젝트 관리자도 배포 동의 여부 선택할 수 있도록 변경
- API 5.6을 통해 프로젝트 관리자가 'Y'라고 보냈을 때 유효성 검사 추가
- 최종 배포를 위한 유효성 검사 통과 시 릴리즈 노트 최종 배포
- 참고: API 5.6 릴리즈 노트 배포 동의 여부 선택