### PR TITLE
REL-38 'API 6.1 릴리즈 노트 의견 추가' 수정

### DIFF
--- a/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
+++ b/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
@@ -108,7 +108,7 @@ public class ReleaseController {
      * 6.1 릴리즈 노트 의견 추가
      */
     @PostMapping(value = "/{releaseId}/opinions")
-    public BaseResponse<ReleaseOpinionCreateResponseDto> addReleaseOpinion(
+    public BaseResponse<List<ReleaseOpinionsResponseDto>> addReleaseOpinion(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable @Min(value = 1, message = "릴리즈 식별 번호는 1 이상의 숫자여야 합니다.") Long releaseId,
             @RequestBody @Valid ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto) {

--- a/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
+++ b/src/main/java/com/momentum/releaser/domain/release/api/ReleaseController.java
@@ -109,10 +109,11 @@ public class ReleaseController {
      */
     @PostMapping(value = "/{releaseId}/opinions")
     public BaseResponse<ReleaseOpinionCreateResponseDto> addReleaseOpinion(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable @Min(value = 1, message = "릴리즈 식별 번호는 1 이상의 숫자여야 합니다.") Long releaseId,
             @RequestBody @Valid ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto) {
 
-        return new BaseResponse<>(releaseService.addReleaseOpinion(releaseId, releaseOpinionCreateRequestDto));
+        return new BaseResponse<>(releaseService.addReleaseOpinion(userPrincipal.getEmail(), releaseId, releaseOpinionCreateRequestDto));
     }
 
     /**

--- a/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
+++ b/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
@@ -45,7 +45,7 @@ public interface ReleaseService {
     /**
      * 6.1 릴리즈 노트 의견 추가
      */
-    ReleaseOpinionCreateResponseDto addReleaseOpinion(Long releaseId, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto);
+    ReleaseOpinionCreateResponseDto addReleaseOpinion(String userEmail, Long releaseId, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto);
 
     /**
      * 6.2 릴리즈 노트 의견 삭제

--- a/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
+++ b/src/main/java/com/momentum/releaser/domain/release/application/ReleaseService.java
@@ -45,7 +45,7 @@ public interface ReleaseService {
     /**
      * 6.1 릴리즈 노트 의견 추가
      */
-    ReleaseOpinionCreateResponseDto addReleaseOpinion(String userEmail, Long releaseId, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto);
+    List<ReleaseOpinionsResponseDto> addReleaseOpinion(String userEmail, Long releaseId, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto);
 
     /**
      * 6.2 릴리즈 노트 의견 삭제

--- a/src/main/java/com/momentum/releaser/domain/release/application/ReleaseServiceImpl.java
+++ b/src/main/java/com/momentum/releaser/domain/release/application/ReleaseServiceImpl.java
@@ -191,9 +191,12 @@ public class ReleaseServiceImpl implements ReleaseService {
      */
     @Transactional
     @Override
-    public ReleaseOpinionCreateResponseDto addReleaseOpinion(Long releaseId, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto) {
+    public ReleaseOpinionCreateResponseDto addReleaseOpinion(String userEmail, Long releaseId, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto) {
         ReleaseNote releaseNote = getReleaseNoteById(releaseId);
-        ProjectMember projectMember = getProjectMemberById(releaseOpinionCreateRequestDto.getMemberId());
+
+        // JWT 토큰을 이용하여 요청을 한 사용자의 프로젝트 멤버 정보를 가져온다.
+        ProjectMember projectMember = getProjectMemberByEmail(releaseNote.getProject(), userEmail);
+
         ReleaseOpinion savedReleaseOpinion = saveReleaseOpinion(releaseNote, projectMember, releaseOpinionCreateRequestDto);
         return ReleaseMapper.INSTANCE.toReleaseOpinionCreateResponseDto(savedReleaseOpinion);
     }

--- a/src/main/java/com/momentum/releaser/domain/release/application/ReleaseServiceImpl.java
+++ b/src/main/java/com/momentum/releaser/domain/release/application/ReleaseServiceImpl.java
@@ -191,14 +191,15 @@ public class ReleaseServiceImpl implements ReleaseService {
      */
     @Transactional
     @Override
-    public ReleaseOpinionCreateResponseDto addReleaseOpinion(String userEmail, Long releaseId, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto) {
+    public List<ReleaseOpinionsResponseDto> addReleaseOpinion(String userEmail, Long releaseId, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto) {
         ReleaseNote releaseNote = getReleaseNoteById(releaseId);
 
         // JWT 토큰을 이용하여 요청을 한 사용자의 프로젝트 멤버 정보를 가져온다.
         ProjectMember projectMember = getProjectMemberByEmail(releaseNote.getProject(), userEmail);
 
-        ReleaseOpinion savedReleaseOpinion = saveReleaseOpinion(releaseNote, projectMember, releaseOpinionCreateRequestDto);
-        return ReleaseMapper.INSTANCE.toReleaseOpinionCreateResponseDto(savedReleaseOpinion);
+        saveReleaseOpinion(releaseNote, projectMember, releaseOpinionCreateRequestDto);
+
+        return createReleaseOpinionsResponseDto(releaseNote);
     }
 
     /**
@@ -931,14 +932,14 @@ public class ReleaseServiceImpl implements ReleaseService {
     /**
      * 릴리즈 노트 의견을 저장한다.
      */
-    private ReleaseOpinion saveReleaseOpinion(ReleaseNote releaseNote, ProjectMember member, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto) {
+    private void saveReleaseOpinion(ReleaseNote releaseNote, ProjectMember member, ReleaseOpinionCreateRequestDto releaseOpinionCreateRequestDto) {
         ReleaseOpinion releaseOpinion = ReleaseOpinion.builder()
                 .opinion(releaseOpinionCreateRequestDto.getOpinion())
                 .release(releaseNote)
                 .member(member)
                 .build();
 
-        return releaseOpinionRepository.save(releaseOpinion);
+        releaseOpinionRepository.save(releaseOpinion);
     }
 
     /**
@@ -1082,5 +1083,16 @@ public class ReleaseServiceImpl implements ReleaseService {
      */
     private ReleaseInfoResponseDto createReleaseInfoResponseDto(ReleaseNote releaseNote, List<ReleaseOpinionsDataDto> opinions) {
         return ReleaseMapper.INSTANCE.toReleaseInfoResponseDto(releaseNote, opinions);
+    }
+
+    /**
+     * ReleaseOpinionsResponseDto 배열 생성 후 변환
+     */
+    private List<ReleaseOpinionsResponseDto> createReleaseOpinionsResponseDto(ReleaseNote releaseNote) {
+        List<ReleaseOpinion> opinions = releaseOpinionRepository.findAllByRelease(releaseNote);
+
+        return opinions.stream()
+                .map(ReleaseMapper.INSTANCE::toReleaseOpinionsResponseDto)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/momentum/releaser/domain/release/dao/opinion/ReleaseOpinionRepository.java
+++ b/src/main/java/com/momentum/releaser/domain/release/dao/opinion/ReleaseOpinionRepository.java
@@ -1,9 +1,15 @@
 package com.momentum.releaser.domain.release.dao.opinion;
 
+import com.momentum.releaser.domain.release.domain.ReleaseNote;
 import com.momentum.releaser.domain.release.domain.ReleaseOpinion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+import java.util.List;
+
 @RepositoryRestResource(collectionResourceRel="release-opinion", path="release-opinion")
 public interface ReleaseOpinionRepository extends JpaRepository<ReleaseOpinion, Long>, ReleaseOpinionRepositoryCustom {
+
+    List<ReleaseOpinion> findAllByRelease(ReleaseNote release);
+
 }

--- a/src/main/java/com/momentum/releaser/domain/release/dto/ReleaseRequestDto.java
+++ b/src/main/java/com/momentum/releaser/domain/release/dto/ReleaseRequestDto.java
@@ -121,16 +121,12 @@ public class ReleaseRequestDto {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class ReleaseOpinionCreateRequestDto {
-        @NotNull(message = "프로젝트 멤버 식별 번호는 1 이상의 숫자여야 합니다.")
-        @Min(value = 1, message = "프로젝트 멤버 식별 번호는 1 이상의 숫자여야 합니다.")
-        private Long memberId;
 
         @NotNull(message = "릴리즈 노트에 대한 의견을 작성해 주세요.")
         private String opinion;
 
         @Builder
-        public ReleaseOpinionCreateRequestDto(Long memberId, String opinion) {
-            this.memberId = memberId;
+        public ReleaseOpinionCreateRequestDto(String opinion) {
             this.opinion = opinion;
         }
     }

--- a/src/main/java/com/momentum/releaser/domain/release/dto/ReleaseResponseDto.java
+++ b/src/main/java/com/momentum/releaser/domain/release/dto/ReleaseResponseDto.java
@@ -128,7 +128,7 @@ public class ReleaseResponseDto {
     }
 
     /**
-     * 6.1 릴리즈 노트 의견 추가
+     * 6.1 릴리즈 노트 의견 추가 (이전)
      */
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -142,7 +142,8 @@ public class ReleaseResponseDto {
     }
 
     /**
-     * 6.3 릴리즈 노트 의견 목록 조회
+     * 6.1 릴리즈 노트 의견 추가
+     * 6.2 릴리즈 노트 의견 삭제
      */
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
## Description
- 릴리즈 노트 의견 추가 시 memberId가 아닌 JWT 토큰으로 프로젝트 멤버 식별
- 릴리즈 노트 의견 추가 response를 생성된 의견의 식별 번호가 아닌 릴리즈 노트의 의견 전체 목록으로 변경